### PR TITLE
Improve plugin

### DIFF
--- a/compressed-emoji.php
+++ b/compressed-emoji.php
@@ -14,19 +14,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-add_filter( 'emoji_url', 'compressed_emoji_url' );
-add_filter( 'emoji_svg_url', 'compressed_emoji_svg_url' );
+add_action( 'plugins_loaded', 'compressed_emoji_init' );
+
+function compressed_emoji_init() {
+	add_filter( 'emoji_url', 'compressed_emoji_url' );
+	add_filter( 'emoji_svg_url', 'compressed_emoji_svg_url' );
+}
 
 function compressed_emoji_url() {
-	$default_url = plugin_dir_url( __FILE__ ) . 'images/png/';
+	$base_url = plugins_url( 'images/png/', __FILE__ );
 
-	return apply_filters( 'compressed_emoji_url', $default_url );
+	return apply_filters( 'compressed_emoji_url', $base_url );
 }
-
 
 function compressed_emoji_svg_url() {
-	$default_url = plugin_dir_url( __FILE__ ) . 'images/svg/';
+	$base_url = plugins_url( 'images/svg/', __FILE__ );
 
-	return apply_filters( 'compressed_emoji_svg_url', $default_url );
+	return apply_filters( 'compressed_emoji_svg_url', $base_url );
 }
-


### PR DESCRIPTION
1. Do not run before `plugins_loaded`
2. Call base URL `$base_url`
3. Use [`plugins_url`](https://developer.wordpress.org/reference/functions/plugins_url/): no more string concatenation!

@mustafauysal 